### PR TITLE
refactor: next/image 대신 img 태그 사용하고 CloudFront 도입

### DIFF
--- a/mechuri/src/app/foodchoice/FoodTest.tsx
+++ b/mechuri/src/app/foodchoice/FoodTest.tsx
@@ -109,13 +109,18 @@ export default function FoodTest() {
                 >
                   <div className="h-full w-full flex flex-col items-center justify-center gap-2 lg:gap-10">
                     {answer.image && (
-                      <Image
+                      // <Image
+                      //   className="rounded-xl h-4/5 lg:h-2/3 aspect-[4/3]"
+                      //   src={answer.image}
+                      //   alt="음식 사진"
+                      //   width={350}
+                      //   height={200}
+                      // />
+                      <img
                         className="rounded-xl h-4/5 lg:h-2/3 aspect-[4/3]"
                         src={answer.image}
                         alt="음식 사진"
-                        width={350}
-                        height={200}
-                      />
+                      ></img>
                     )}
                     <div className="font-semibold text-xl lg:text-4xl text-gray-800">
                       {answer.longAnswer}


### PR DESCRIPTION
## 🔍️ PR 타입

- [ ] 기능 추가
- [ ] 버그 수정
- [x] 코드 리팩토링
- [ ] 디자인 수정

## ⭐ 변경 사항에 대해 설명해주세요.

- img 태그로 바꾸었습니다.

## ✅ 공유 사항 to 리뷰어

- next/image 태그를 사용하지 않고, img 태그를 사용하기로 결정했습니다.
- 그리고 추가적으로 CloudFront를 도입하여 CDN을 사용하기로 했습니다.
